### PR TITLE
Bump cross-platform-actions to 0.23.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           - name: 7.4-amd64
             arch: x86-64
             version: "7.4"
-            host: macos-12
+            host: ubuntu-latest
             do-git-push: true  # Push changes from this build back to the branch
           - name: 7.4-arm64
             arch: arm64
@@ -36,11 +36,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build
-        uses: cross-platform-actions/action@v0.22.0
+        uses: cross-platform-actions/action@v0.23.0
         with:
           operating_system: openbsd
           architecture: ${{ matrix.os.arch }}
           version: "${{ matrix.os.version }}"
+          cpu_count: 4
           shell: bash
           shutdown_vm: false
           run: |


### PR DESCRIPTION
This version supports HW acceleration on Ubuntu runners.

While here, bump CPU count of the VM to 4 (from default of 2).